### PR TITLE
Add log unifier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# AIData
+# AI Data Log Unifier
+
+This repository contains a simple example of how you might aggregate logs from Amazon S3 and Firebase Crashlytics using Python. The `log_unifier.py` script downloads log files from the specified S3 bucket and retrieves Crashlytics crash reports via BigQuery. The combined logs are saved locally for easy inspection.
+
+## Requirements
+
+- Python 3.8+
+- AWS credentials with read access to the target S3 bucket
+- Google Cloud credentials with access to the Crashlytics BigQuery dataset
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Edit the configuration variables at the top of `log_unifier.py` to point to your S3 bucket and BigQuery dataset. Then run:
+
+```bash
+python log_unifier.py
+```
+
+The script downloads the logs and merges them into `merged_logs.jsonl`.
+
+## Disclaimer
+
+This is a minimal example intended for demonstration purposes only. A production-ready desktop application would require additional features such as a graphical user interface, incremental log fetching, and error handling.

--- a/log_unifier.py
+++ b/log_unifier.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+import boto3
+from google.cloud import bigquery
+
+# Configuration -- edit these values
+S3_BUCKET = "your-s3-bucket"
+S3_PREFIX = "logs/"  # prefix inside the bucket
+BIGQUERY_DATASET = "your_project.your_dataset"
+CRASHLYTICS_TABLE = "firebase_crashlytics"  # exported table name
+OUTPUT_FILE = Path("merged_logs.jsonl")
+
+
+def fetch_s3_logs(bucket: str, prefix: str) -> list[dict]:
+    """Download JSON log files from S3 and return list of entries."""
+    s3 = boto3.client("s3")
+    logs = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".json"):
+                continue
+            body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            logs.extend(json.loads(body))
+    return logs
+
+
+def fetch_crashlytics_logs(dataset: str, table: str) -> list[dict]:
+    """Query Crashlytics BigQuery export and return list of entries."""
+    client = bigquery.Client()
+    query = f"SELECT * FROM `{dataset}.{table}`"
+    rows = client.query(query).result()
+    return [dict(row) for row in rows]
+
+
+def main() -> None:
+    s3_logs = fetch_s3_logs(S3_BUCKET, S3_PREFIX)
+    crash_logs = fetch_crashlytics_logs(BIGQUERY_DATASET, CRASHLYTICS_TABLE)
+    with OUTPUT_FILE.open("w", encoding="utf-8") as f:
+        for entry in s3_logs + crash_logs:
+            f.write(json.dumps(entry) + "\n")
+    print(f"Merged {len(s3_logs) + len(crash_logs)} records into {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+google-cloud-bigquery


### PR DESCRIPTION
## Summary
- sketch out instructions and requirements in README
- add example `log_unifier.py` script for downloading logs from S3 and Crashlytics BigQuery
- include `requirements.txt` for dependencies

## Testing
- `python3 -m py_compile log_unifier.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687fa0a769188320bc9e8f3d286b9cc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a script to unify logs from Amazon S3 and Firebase Crashlytics (via BigQuery), producing a merged log file.
* **Documentation**
  * Completely rewrote and expanded the README with detailed project overview, setup instructions, usage guidance, and disclaimers.
* **Chores**
  * Added a requirements file listing necessary dependencies for installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->