### PR TITLE
Introduce Crypt Mainica Android app and FastAPI backend and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,64 @@
-# AI Data Log Unifier
+# Crypt Mainica Android + Backend
 
+This repository now contains **two separate runnable projects**:
 
-## Requirements
+1. `crypt_mainica_backend/` → FastAPI realtime signal backend.
+2. `crypt_mainica_android/` → Android app project (Manifest + Gradle + Compose UI).
 
-- Python 3.8+
-- AWS credentials with read access to the target S3 bucket
-- Google Cloud credentials with access to the Crashlytics BigQuery dataset
+Legacy log-unifier scripts remain in root (`log_unifier.py`, `desktop_unifier.py`) but are not part of Crypt Mainica.
 
-Install dependencies:
+---
 
-```bash
-pip install -r requirements.txt
-```
+## 1) Crypt Mainica Backend
 
-## Usage
+Location: `crypt_mainica_backend/`
 
-
-```bash
-python log_unifier.py
-```
-
-The script downloads the logs and merges them into `merged_logs.jsonl`.
-
-## Desktop GUI
-
-`desktop_unifier.py` provides a minimal Tkinter interface. Use the **Settings** menu to configure AWS credentials, S3 bucket information, and Crashlytics/Firebase keys such as your BigQuery dataset, Firebase API key, and Crashlytics token. These details are saved to `settings.json` for next time.
-
-Run the GUI with:
+### Install
 
 ```bash
-python desktop_unifier.py
+pip install -r crypt_mainica_backend/requirements.txt
 ```
 
-## Disclaimer
+### Run
 
+```bash
+uvicorn crypt_mainica_backend.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Endpoints
+
+- `GET /health`
+- `GET /signals/top?top_n=10`
+- `WS /signals/ws`
+
+---
+
+## 2) Crypt Mainica Android
+
+Location: `crypt_mainica_android/`
+
+This is now a **real Android app project** with:
+
+- `settings.gradle.kts`
+- Root/app `build.gradle.kts`
+- `AndroidManifest.xml`
+- `MainActivity.kt`
+- Compose UI screen and ViewModel
+- Retrofit + WebSocket networking
+
+### Open and run
+
+1. Open `crypt_mainica_android/` in Android Studio.
+2. Sync Gradle.
+3. Run app on emulator/device.
+4. Ensure backend is running on `http://10.0.2.2:8000` (default emulator host mapping).
+
+If using a physical device, update base URLs in:
+
+- `crypt_mainica_android/app/src/main/java/com/cryptmainica/app/data/Network.kt`
+
+---
+
+## Project rename
+
+The active product name is now **Crypt Mainica** (Android + Backend).

--- a/crypt_mainica_android/app/build.gradle.kts
+++ b/crypt_mainica_android/app/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.cryptmainica.app"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.cryptmainica.app"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.compose.ui:ui:1.7.7")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.7.7")
+    implementation("androidx.compose.material3:material3:1.3.1")
+
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+    debugImplementation("androidx.compose.ui:ui-tooling:1.7.7")
+}

--- a/crypt_mainica_android/app/proguard-rules.pro
+++ b/crypt_mainica_android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep default minimal rules for MVP.

--- a/crypt_mainica_android/app/src/main/AndroidManifest.xml
+++ b/crypt_mainica_android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="Crypt Mainica"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.CryptMainica">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/MainActivity.kt
+++ b/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/MainActivity.kt
@@ -1,0 +1,23 @@
+package com.cryptmainica.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.cryptmainica.app.ui.CoinDashboardScreen
+import com.cryptmainica.app.ui.SignalViewModel
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            val vm: SignalViewModel = viewModel()
+            val state by vm.uiState.collectAsState()
+            CoinDashboardScreen(state = state, onRefresh = vm::refresh)
+        }
+    }
+}

--- a/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/data/Models.kt
+++ b/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/data/Models.kt
@@ -1,0 +1,20 @@
+package com.cryptmainica.app.data
+
+data class SignalCoin(
+    val pair_address: String,
+    val token_symbol: String,
+    val token_name: String,
+    val price_usd: Double,
+    val volume_h24: Double,
+    val liquidity_usd: Double,
+    val buy_sell_ratio: Double,
+    val score: Int,
+    val signal: String,
+    val risks: List<String>
+)
+
+data class UiState(
+    val loading: Boolean = true,
+    val items: List<SignalCoin> = emptyList(),
+    val error: String? = null
+)

--- a/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/data/Network.kt
+++ b/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/data/Network.kt
@@ -1,0 +1,41 @@
+package com.cryptmainica.app.data
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+
+interface SignalApi {
+    @GET("signals/top")
+    suspend fun topSignals(): List<SignalCoin>
+}
+
+object NetworkModule {
+    // Change this to your machine IP when running on a physical device/emulator.
+    const val BASE_HTTP = "http://10.0.2.2:8000/"
+    const val BASE_WS = "ws://10.0.2.2:8000/signals/ws"
+
+    val api: SignalApi by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_HTTP)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(SignalApi::class.java)
+    }
+
+    fun connectSignals(listener: WebSocketListener): WebSocket {
+        val client = OkHttpClient()
+        val request = Request.Builder().url(BASE_WS).build()
+        return client.newWebSocket(request, listener)
+    }
+}
+
+open class SafeWebSocketListener : WebSocketListener() {
+    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+        // no-op; handled in ViewModel
+    }
+}

--- a/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/ui/CoinDashboardScreen.kt
+++ b/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/ui/CoinDashboardScreen.kt
@@ -1,0 +1,94 @@
+package com.cryptmainica.app.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.cryptmainica.app.data.SignalCoin
+import com.cryptmainica.app.data.UiState
+
+@Composable
+fun CoinDashboardScreen(state: UiState, onRefresh: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF0B1020)),
+        contentAlignment = Alignment.Center,
+    ) {
+        when {
+            state.loading -> CircularProgressIndicator()
+            state.items.isEmpty() -> EmptyState(state.error, onRefresh)
+            else -> CoinList(state.items, onRefresh)
+        }
+    }
+}
+
+@Composable
+private fun EmptyState(error: String?, onRefresh: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = error ?: "No live signals yet",
+            color = Color.White,
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Button(onClick = onRefresh, modifier = Modifier.padding(top = 12.dp)) {
+            Text("Retry")
+        }
+    }
+}
+
+@Composable
+private fun CoinList(items: List<SignalCoin>, onRefresh: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize().padding(12.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Crypt Mainica", color = Color.White, fontWeight = FontWeight.Bold)
+            Button(onClick = onRefresh) { Text("Refresh") }
+        }
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(top = 8.dp)) {
+            items(items, key = { it.pair_address }) { coin ->
+                CoinCard(coin)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoinCard(coin: SignalCoin) {
+    val signalColor = when (coin.signal) {
+        "STRONG_BUY" -> Color(0xFF22C55E)
+        "WATCH" -> Color(0xFFEAB308)
+        "RISKY" -> Color(0xFFF97316)
+        else -> Color(0xFFEF4444)
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("${coin.token_name} (${coin.token_symbol})", fontWeight = FontWeight.Bold)
+            Text("Score: ${coin.score}", color = signalColor)
+            Text("Price: $${coin.price_usd}")
+            Text("Volume: $${coin.volume_h24}")
+            Text("Liquidity: $${coin.liquidity_usd}")
+            Text("Buy/Sell: ${coin.buy_sell_ratio}")
+            if (coin.risks.isNotEmpty()) {
+                Text("Risk: ${coin.risks.joinToString()}", color = Color(0xFFDC2626))
+            }
+        }
+    }
+}

--- a/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/ui/SignalViewModel.kt
+++ b/crypt_mainica_android/app/src/main/java/com/cryptmainica/app/ui/SignalViewModel.kt
@@ -1,0 +1,58 @@
+package com.cryptmainica.app.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cryptmainica.app.data.NetworkModule
+import com.cryptmainica.app.data.SafeWebSocketListener
+import com.cryptmainica.app.data.SignalCoin
+import com.cryptmainica.app.data.UiState
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import okhttp3.Response
+import okhttp3.WebSocket
+
+class SignalViewModel : ViewModel() {
+    private val gson = Gson()
+    private var socket: WebSocket? = null
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState
+
+    init {
+        refresh()
+        connectSocket()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(loading = true, error = null) }
+            runCatching { NetworkModule.api.topSignals() }
+                .onSuccess { rows -> _uiState.update { it.copy(loading = false, items = rows, error = null) } }
+                .onFailure { e -> _uiState.update { it.copy(loading = false, error = e.message ?: "Request failed") } }
+        }
+    }
+
+    private fun connectSocket() {
+        socket = NetworkModule.connectSignals(object : SafeWebSocketListener() {
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                val type = object : TypeToken<List<SignalCoin>>() {}.type
+                val rows: List<SignalCoin> = gson.fromJson(text, type)
+                _uiState.update { it.copy(items = rows, loading = false, error = null) }
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                _uiState.update { it.copy(error = t.message ?: "WebSocket failed") }
+            }
+        })
+    }
+
+    override fun onCleared() {
+        socket?.close(1000, "closing")
+        socket = null
+        super.onCleared()
+    }
+}

--- a/crypt_mainica_android/app/src/main/res/values/strings.xml
+++ b/crypt_mainica_android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Crypt Mainica</string>
+</resources>

--- a/crypt_mainica_android/app/src/main/res/values/themes.xml
+++ b/crypt_mainica_android/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.CryptMainica" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/crypt_mainica_android/build.gradle.kts
+++ b/crypt_mainica_android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.6.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/crypt_mainica_android/settings.gradle.kts
+++ b/crypt_mainica_android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Crypt Mainica Android"
+include(":app")

--- a/crypt_mainica_backend/main.py
+++ b/crypt_mainica_backend/main.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+
+DEXSCREENER_URL = "https://api.dexscreener.com/latest/dex/pairs/solana"
+POLL_SECONDS = int(os.getenv("POLL_SECONDS", "15"))
+
+
+@dataclass
+class SignalCoin:
+    pair_address: str
+    token_symbol: str
+    token_name: str
+    price_usd: float
+    volume_h24: float
+    liquidity_usd: float
+    buy_sell_ratio: float
+    score: int
+    signal: str
+    risks: list[str]
+    updated_at: str
+
+
+app = FastAPI(title="Crypt Mainica Backend", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+LATEST_TOP10: list[SignalCoin] = []
+
+
+def _float(v: Any) -> float:
+    try:
+        return float(v)
+    except Exception:
+        return 0.0
+
+
+def _int(v: Any) -> int:
+    try:
+        return int(v)
+    except Exception:
+        return 0
+
+
+def classify(score: int) -> str:
+    if score >= 80:
+        return "STRONG_BUY"
+    if score >= 60:
+        return "WATCH"
+    if score >= 40:
+        return "RISKY"
+    return "AVOID"
+
+
+def score_pair(pair: dict[str, Any]) -> tuple[int, float, list[str]]:
+    volume_h24 = _float(pair.get("volume", {}).get("h24"))
+    liquidity = _float(pair.get("liquidity", {}).get("usd"))
+    buys = _int(pair.get("txns", {}).get("h24", {}).get("buys"))
+    sells = _int(pair.get("txns", {}).get("h24", {}).get("sells"))
+    ratio = buys / max(sells, 1)
+    tx_count = buys + sells
+
+    risks: list[str] = []
+    score = 0
+
+    # Volume spike (0-25)
+    if volume_h24 > 250_000:
+        score += 25
+    elif volume_h24 > 100_000:
+        score += 18
+    elif volume_h24 > 50_000:
+        score += 12
+
+    # Buy/Sell pressure (0-20)
+    if ratio >= 1.8:
+        score += 20
+    elif ratio >= 1.5:
+        score += 14
+    elif ratio >= 1.2:
+        score += 8
+    elif ratio < 0.7:
+        risks.append("bearish-pressure")
+
+    # Whale activity proxy (0-20)
+    if tx_count >= 400:
+        score += 20
+    elif tx_count >= 200:
+        score += 12
+
+    # Liquidity strength (0-15)
+    if 20_000 <= liquidity <= 200_000:
+        score += 15
+    elif liquidity < 10_000:
+        risks.append("low-liquidity")
+
+    # Social momentum proxy (0-20)
+    if tx_count >= 300:
+        score += 20
+    elif tx_count >= 120:
+        score += 10
+
+    # Rug checks
+    if liquidity < 20_000:
+        risks.append("rug-risk")
+    if ratio > 4.0 and sells <= 2:
+        risks.append("possible-honeypot")
+
+    return min(score, 100), ratio, risks
+
+
+def pass_filters(pair: dict[str, Any]) -> bool:
+    liquidity = _float(pair.get("liquidity", {}).get("usd"))
+    volume = _float(pair.get("volume", {}).get("h24"))
+    created_ms = _int(pair.get("pairCreatedAt"))
+
+    if liquidity < 10_000 or volume < 50_000:
+        return False
+
+    if created_ms > 0:
+        age_hours = (datetime.now(timezone.utc).timestamp() - (created_ms / 1000)) / 3600
+        if age_hours > 24:
+            return False
+
+    return True
+
+
+async def fetch_pairs() -> list[dict[str, Any]]:
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(DEXSCREENER_URL)
+            response.raise_for_status()
+            return response.json().get("pairs", [])
+    except Exception:
+        return []
+
+
+async def compute_top(top_n: int = 10) -> list[SignalCoin]:
+    pairs = await fetch_pairs()
+    rows: list[SignalCoin] = []
+
+    for pair in pairs:
+        if not pass_filters(pair):
+            continue
+
+        score, ratio, risks = score_pair(pair)
+        rows.append(
+            SignalCoin(
+                pair_address=str(pair.get("pairAddress", "")),
+                token_symbol=str(pair.get("baseToken", {}).get("symbol", "")),
+                token_name=str(pair.get("baseToken", {}).get("name", "")),
+                price_usd=_float(pair.get("priceUsd")),
+                volume_h24=_float(pair.get("volume", {}).get("h24")),
+                liquidity_usd=_float(pair.get("liquidity", {}).get("usd")),
+                buy_sell_ratio=round(ratio, 3),
+                score=score,
+                signal=classify(score),
+                risks=risks,
+                updated_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+
+    rows.sort(key=lambda x: x.score, reverse=True)
+    return rows[:top_n]
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": "crypt-mainica-backend"}
+
+
+@app.get("/signals/top")
+async def top_signals(top_n: int = 10) -> list[dict[str, Any]]:
+    global LATEST_TOP10
+    if not LATEST_TOP10:
+        LATEST_TOP10 = await compute_top(top_n)
+    return [asdict(x) for x in LATEST_TOP10[:top_n]]
+
+
+@app.websocket("/signals/ws")
+async def signals_ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            payload = await compute_top(10)
+            await websocket.send_json([asdict(x) for x in payload])
+            await asyncio.sleep(POLL_SECONDS)
+    except WebSocketDisconnect:
+        return
+
+
+@app.on_event("startup")
+async def startup_refresh() -> None:
+    async def updater() -> None:
+        global LATEST_TOP10
+        while True:
+            LATEST_TOP10 = await compute_top(10)
+            await asyncio.sleep(POLL_SECONDS)
+
+    asyncio.create_task(updater())

--- a/crypt_mainica_backend/requirements.txt
+++ b/crypt_mainica_backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+# Legacy dependencies for the original log-unifier scripts
 boto3
 google-cloud-bigquery


### PR DESCRIPTION
### Motivation
- Convert the repository into a runnable product named Crypt Mainica with a lightweight Android client and a realtime backend for serving live coin signals.
- Ship a minimal Compose-based Android app that consumes HTTP and WebSocket signal endpoints and a FastAPI backend that fetches/publishes top signal data from an external pairs API.
- Preserve legacy log-unifier scripts in the repo root while separating them from the new product directories.

### Description
- Add a FastAPI backend at `crypt_mainica_backend/` implementing scoring logic (`score_pair`, `score_pair`, `pass_filters`), endpoints `GET /health`, `GET /signals/top`, and a WebSocket `WS /signals/ws`, plus `requirements.txt` and startup polling task in `main.py`.
- Add an Android app project under `crypt_mainica_android/` with Gradle/Kotlin config, Compose UI (`CoinDashboardScreen.kt`), `SignalViewModel.kt`, networking via Retrofit/OkHttp in `Network.kt`, models in `Models.kt`, and Android manifest/resources; include `settings.gradle.kts` and module `app/build.gradle.kts`.
- Update `README.md` to reflect the new repository layout, run instructions for the backend (`uvicorn crypt_mainica_backend.main:app --reload --host 0.0.0.0 --port 8000`) and guidance for opening the Android project and emulator host mapping, and note legacy scripts remain in root.
- Adjust top-level `requirements.txt` to indicate legacy dependencies while moving runtime backend deps to `crypt_mainica_backend/requirements.txt`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0bedf10083209e15f9115ff7c3cf)